### PR TITLE
Updated Neutral Density filter wheel names in bot-bench properties file

### DIFF
--- a/IR2/lsst-uno11/bot-bench_safe.properties
+++ b/IR2/lsst-uno11/bot-bench_safe.properties
@@ -32,7 +32,7 @@ NeutralFWheel/fwsize = 6
 #** Names of filters in filter wheel, in order of position
 #** type : List<String>
 #********
-NeutralFWheel/filterNames = [ND_OD1.0, ND_OD0.5, ND_OD0.3, ND_OD0.05, ND_OD0.01, empty]
+NeutralFWheel/filterNames = [ND_OD1.0, ND_OD0.5, ND_OD0.3, empty, ND_OD2.0, ND_OD0.7]
 
 #********  ColorFWheel/devcId
 #** port ID


### PR DESCRIPTION
The installed neutral density filters in the neutral density filter wheel have been changed.  The appropriate configuration file has been updated with the appropriate filter names to match these changes.